### PR TITLE
Add GOPATH ENV to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM crosbymichael/golang
 
+ENV GOPATH=/app
+
 ADD . /app/
 WORKDIR /app/
 RUN go build dockerui.go


### PR DESCRIPTION
I had to add the GOPATH env variable to build the image succesfully as I was getting the following error during docker build:
dockerui.go:17:5: cannot find package "authui" in any of:
/usr/local/go/src/pkg/authui (from $GOROOT)
/go/src/authui (from $GOPATH)

Regards,
